### PR TITLE
Remove wget from build and run

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,4 +9,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- 3.6.* *_cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,11 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
 
 requirements:
   build:
     - bash
-    - wget
   host:
     - python
     - pip
@@ -27,7 +26,6 @@ requirements:
   run:
     - python
     - cartopy
-    - wget
 
 test:
   requires:


### PR DESCRIPTION
Likely not needed in build and causes problems on Windows in
run (where it is also not needed)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #3 